### PR TITLE
Week 1 demo feedback

### DIFF
--- a/server/controllers/trip_controller.js
+++ b/server/controllers/trip_controller.js
@@ -65,7 +65,7 @@ class TripController {
       }
 
       Trip.cancel(res, req.params);
-      return res.status(status.RESOURCE_CREATED).send({ status: status.RESOURCE_CREATED, data: { message: 'Trip cancelled successfully' } });
+      return res.status(status.REQUEST_SUCCEDED).send({ status: status.REQUEST_SUCCEDED, data: { message: 'Trip cancelled successfully' } });
     }
 }
 

--- a/server/routes/trip_route.js
+++ b/server/routes/trip_route.js
@@ -11,10 +11,10 @@ const trip_controller = new TripController();
 router.post('/', admin, trip_controller.createTrip);
 
 // Get a specific trip: admins + users
-router.get('/:id', auth, trip_controller.findOneTrip);
+router.get('/:id', trip_controller.findOneTrip);
 
 // Both admin and users can see all trips
-router.get('/', auth, trip_controller.findAllTrip);
+router.get('/',  trip_controller.findAllTrip);
 
 // Cancel a trip: only admin can be able to cancel
 // a certain trip

--- a/server/test/tripTest.js
+++ b/server/test/tripTest.js
@@ -30,7 +30,6 @@ describe('GET Both Admin and Users can see all trips, api/v1/trips', () => {
   it('should return all trips', (done) => {
     chai.request(app)
       .get('/api/v1/trips')
-      .set('x-auth-token', token)
       .set('Accept', 'application/json')
       .end((err, res) => {
         expect(res.body).to.be.an('object');
@@ -50,7 +49,6 @@ describe('GET View a specific trip api/v1/trips/{Trip_id}', () => {
   it('should return a specific trip', (done) => {
     chai.request(app)
       .get('/api/v1/trips/1')
-      .set('x-auth-token', token)
       .set('Accept', 'application/json')
       .end((err, res) => {
         expect(res.body).to.be.an('object');
@@ -68,7 +66,6 @@ describe('GET View specifc trip with an id not an integer', () => {
   it('should return an error', (done) => {
     chai.request(app)
       .get('/api/v1/trips/k')
-      .set('x-auth-token', token)
       .set('Accept', 'application/json')
       .end((err, res) => {
         expect(res.body).to.be.an('object');
@@ -85,7 +82,6 @@ describe('GET view specific , api/v1/trips', () => {
   it('should return an error', (done) => {
     chai.request(app)
       .get('/api/v1/trips/9000')
-      .set('x-auth-token', token)
       .set('Accept', 'application/json')
       .end((err, res) => {
         expect(res.body).to.be.an('object');
@@ -98,21 +94,6 @@ describe('GET view specific , api/v1/trips', () => {
   });
 });
 
-describe('GET user with invalid token, api/v1/trips', () => {
-  it('should return all trips', (done) => {
-    chai.request(app)
-      .get('/api/v1/trips')
-      .set('x-auth-token', Invalidtoken)
-      .set('Accept', 'application/json')
-      .end((err, res) => {
-        expect(res.body).to.be.an('object');
-        expect(res.body.status).to.equal(status.NOT_FOUND);
-        expect(res.body.error).to.equal('The User associated with this token doesn\'t exist.');
-        // expect(res.body.data.token).to.be.a('string');
-        done();
-      });
-  });
-});
 
 // Test to create a new trip
 
@@ -143,9 +124,9 @@ describe('PATCH Admin can cancel a trip, api/v1/trips', () => {
       .set('Accept', 'application/json')
       .end((err, res) => {
         expect(res.body).to.be.an('object');
-        expect(res.body.status).to.equal(status.RESOURCE_CREATED);
+        expect(res.body.status).to.equal(status.REQUEST_SUCCEDED);
         expect(res.body.data.message).to.equal('Trip cancelled successfully');
-        expect(res.status).to.equal(status.RESOURCE_CREATED);
+        expect(res.status).to.equal(status.REQUEST_SUCCEDED);
         // expect(res.body.data.token).to.be.a('string');
         done();
       });
@@ -168,11 +149,10 @@ describe('PATCH Admin can cancel an already cancelled trip, api/v1/trips', () =>
 });
 
 describe('PATCH params incompleteness, api/v1/trips', () => {
-  it('should create a new trip successfully', (done) => {
+  it('should return an error', (done) => {
     chai.request(app)
       .patch('/api/v1/trips/1/cance')
       .set('x-auth-token', token)
-
       .set('Accept', 'application/json')
       .end((err, res) => {
         expect(res.body).to.be.an('object');
@@ -204,7 +184,7 @@ describe('PATCH trip id which is not an integer, api/v1/trips', () => {
 });
 
 describe('PATCH admin provide wrong id, api/v1/trips', () => {
-  it('should create a new trip successfully', (done) => {
+  it('should return an error', (done) => {
     chai.request(app)
       .patch('/api/v1/trips/9/cancel')
       .set('x-auth-token', token)


### PR DESCRIPTION
#### What does this PR do?
- Remove authentication to view trips
- Change response status code on cancel trip
#### Description of Task to be completed?
1. authentication to view trips: previously users weren't able to view trips
   or a specific trip unless they are authenticated with their tokens.
  However, authentication is not necessary for viewing the trips so authentication has been removed
2. Status code on cancel trip: previously, If a user cancels the trip the response status code for success was 201 which wrong, so it has been changed to 200

#### How should this be manually tested?
##### Method 1: 
Use [Heroku api(view trips)](https://adc-wayfarer-api.herokuapp.com/api/v1/trips) &  [Heroku api(Cancel trip)](https://adc-wayfarer-api.herokuapp.com/api/v1/trips/1/cancel) in Postman app with `GET`  & `PATCH` method  respectively

##### Method 2:
- Clone this project
- Run `npm install` to install all dependencies in your terminal
- run `npm start` then go in Postman and use `127.0.0.1:5000/api/v1/trips` & `127.0.0.1:5000/api/v1/trips/1/cancel` with `GET` & `PATCH` method respectively
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
   [PT Link](https://www.pivotaltracker.com/story/show/167847758)
#### Screenshots
Authentication is not necessary to view trips
![auth](https://user-images.githubusercontent.com/35301129/62881590-6f9ab300-bd30-11e9-8576-3b56a9394275.JPG)

Response status code after canceling trip successfully
![status](https://user-images.githubusercontent.com/35301129/62881592-70334980-bd30-11e9-8d95-119cee3a4453.JPG)

#### Questions:
N/A